### PR TITLE
Setup DDEV homeadditions in entrypoint.sh

### DIFF
--- a/playwright-build/entrypoint.sh
+++ b/playwright-build/entrypoint.sh
@@ -14,9 +14,11 @@ usermod -a -G ssl-cert pwuser
 # Install DDEV certificate
 mkcert -install
 
-# Set up .nprm rc if present. This might contain credentials for private registries
-[ -f "/mnt/ddev_config/.homeadditions/.npmrc" ] && ln -s "/mnt/ddev_config/.homeadditions/.npmrc" /home/pwuser/.npmrc
-
+# Set up homeadditions if present
+if [ -d /mnt/ddev_config/.homeadditions ]; then
+    # Since we already modified UID/GID, the -p option preserves the correct permissions
+    cp -pr /mnt/ddev_config/.homeadditions/. /home/pwuser/
+fi
 
 # Run CMD from parameters as pwuser
 sudo -u pwuser vncserver -fg -disableBasicAuth

--- a/playwright-build/entrypoint.sh
+++ b/playwright-build/entrypoint.sh
@@ -14,5 +14,9 @@ usermod -a -G ssl-cert pwuser
 # Install DDEV certificate
 mkcert -install
 
+# Set up .nprm rc if present. This might contain credentials for private registries
+[ -f "/mnt/ddev_config/.homeadditions/.npmrc" ] && ln -s "/mnt/ddev_config/.homeadditions/.npmrc" /home/pwuser/.npmrc
+
+
 # Run CMD from parameters as pwuser
 sudo -u pwuser vncserver -fg -disableBasicAuth


### PR DESCRIPTION
Since playwright lives in a separate container, it does not benefit from all the homeadditions-magic that DDEV pours into the `web`-container.
This means that if you have some private NPM registries configured (and use private modules for tests), they are not automatically picked up by `ddev playwright-install`, resulting in errors during installation.

Luckily, we have access to `/mnt/ddev_config`, which still lets us access it. 

This PR copies the existing `homeadditions` folder into `/home/pwuser` so that they are readable by the `pwuser` that installs playwright