### PR TITLE
Use NPM if `package.lock` exists

### DIFF
--- a/commands/playwright/playwright
+++ b/commands/playwright/playwright
@@ -14,4 +14,8 @@ cd "${PLAYWRIGHT_TEST_DIR}" || exit 1
 export PLAYWRIGHT_BROWSERS_PATH=0
 PRE="sudo -u pwuser PLAYWRIGHT_BROWSERS_PATH=0 "
 
-$PRE yarn playwright "$@"
+if [ -e "package-lock.json" ]; then
+  $PRE npm playwright "$@"
+else
+  $PRE yarn playwright "$@"
+fi

--- a/commands/playwright/playwright
+++ b/commands/playwright/playwright
@@ -15,7 +15,7 @@ export PLAYWRIGHT_BROWSERS_PATH=0
 PRE="sudo -u pwuser PLAYWRIGHT_BROWSERS_PATH=0 "
 
 if [ -e "package-lock.json" ]; then
-  $PRE npm playwright "$@"
+  $PRE npx playwright "$@"
 else
   $PRE yarn playwright "$@"
 fi

--- a/commands/playwright/playwright-install
+++ b/commands/playwright/playwright-install
@@ -14,9 +14,9 @@ cd "${PLAYWRIGHT_TEST_DIR}" || exit 1
 export PLAYWRIGHT_BROWSERS_PATH=0
 PRE="sudo -u pwuser PLAYWRIGHT_BROWSERS_PATH=0 "
 
-if [ -e "package-lock.json" ]; then
+if [ -e "/var/www/html/package-lock.json" ]; then
   $PRE npm install
-  $PRE npm playwright install --with-deps
+  $PRE npm init playwright@latest -y
 else
   $PRE yarn install
   $PRE yarn playwright install --with-deps

--- a/commands/playwright/playwright-install
+++ b/commands/playwright/playwright-install
@@ -14,7 +14,13 @@ cd "${PLAYWRIGHT_TEST_DIR}" || exit 1
 export PLAYWRIGHT_BROWSERS_PATH=0
 PRE="sudo -u pwuser PLAYWRIGHT_BROWSERS_PATH=0 "
 
-$PRE yarn install
-$PRE yarn playwright install --with-deps
+if [ -e "package-lock.json" ]; then
+  $PRE npm install
+  $PRE npm playwright install --with-deps
+else
+  $PRE yarn install
+  $PRE yarn playwright install --with-deps
+fi
+
 # Conditionally copy an .env file if an example file exists
 [ -f .env.example ] && [ ! -f .env ] && $PRE cp -n .env.example .env; exit 0

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -107,3 +107,35 @@ teardown() {
       exit 1
   fi
 }
+
+@test "it uses NPM package manager" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
+
+  echo "# Basic Curl check" >&3
+  CURLVERIF=$(curl https://${PROJNAME}.ddev.site/home.php | grep -o -E "<h1>(.*)</h1>"  | sed 's/<\/h1>//g; s/<h1>//g;' | tr '\n' '#')
+  if [[ $CURLVERIF == "The way is clear!#" ]]
+    then
+      echo "# CURLVERIF OK" >&3
+    else
+      echo "# CURLVERIF KO"
+      echo $CURLVERIF
+      exit 1
+  fi
+
+  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ${DIR}
+  ddev restart
+
+  # Install a package with NPM to generate ".lock" file
+  ddev npm add playwright-helpers
+
+  echo "# Install Playwright in container" >&3
+  ddev playwright-install
+
+  if [ -e "yarn.lock" ]; then
+      echo "Yarn appears to have been used"
+      exit 1
+  fi
+
+}


### PR DESCRIPTION
This (draft) PR attempts to use the preferred package manager.

It does this by checking for a `package-lock.json`, which implies a NPM based project, and using NPM to install playwright.

It falls back to yarn, the addons current preferred manager, if `package-lock.json` is not detected.

This is a simply approach, which will probably work well if developers follow best practises and only use `npm` or `yarn` commands. 

Fixes #12