### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,21 @@ This DDEV add-on allows you to use Playwright in a separate `playwright` service
 
 ## Installation
 
+For DDEV v1.23.5 or above run
+
+```bash
+ddev add-on get julienloizelet/ddev-playwright
+```
+
+For earlier versions of DDEV run
+
 ```bash
 ddev get julienloizelet/ddev-playwright
+```
+
+Then restart your project
+
+```bash
 ddev restart
 ```
 
@@ -77,7 +90,7 @@ services:
 ```
 
 
-You could also edit the value directly in the `docker-compose.playwright.yaml` file, but you risk losing your changes every time you do a  `ddev get julienloizelet/ddev-playwright` (unless you delete the `#ddev-generated` line at the beginning of the file).
+You could also edit the value directly in the `docker-compose.playwright.yaml` file, but you risk losing your changes every time you do a  `ddev add-on get julienloizelet/ddev-playwright` (unless you delete the `#ddev-generated` line at the beginning of the file).
 
 #### `.env` file
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.