### PR TITLE
fix: add support for multiple hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![tests](https://github.com/julienloizelet/ddev-playwright/actions/workflows/tests.yml/badge.svg)](https://github.com/julienloizelet/ddev-playwright/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/julienloizelet/ddev-playwright/actions/workflows/tests.yml/badge.svg)](https://github.com/julienloizelet/ddev-playwright/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2025.svg)
 [![Version](https://img.shields.io/github/v/release/julienloizelet/ddev-playwright)](https://github.com/julienloizelet/ddev-playwright/releases)
 
 # ddev-playwright
@@ -30,7 +30,7 @@
 
 ## Introduction
 
-[Playwright](https://playwright.dev) was created to accommodate the needs of end-to-end testing. 
+[Playwright](https://playwright.dev) was created to accommodate the needs of end-to-end testing.
 
 This DDEV add-on allows you to use Playwright in a separate `playwright` service.
 
@@ -54,6 +54,9 @@ Then restart your project
 ```bash
 ddev restart
 ```
+
+> [!NOTE]
+> If you change `additional_hostnames` or `additional_fqdns`, you have to re-run `ddev add-on get julienloizelet/ddev-playwright`
 
 ## Basic usage
 
@@ -108,9 +111,9 @@ This command will install `playwright` and all dependencies in a folder defined 
 You can choose to use `npm` or `yarn` as package manager by using the `--pm` option. By default, `yarn` is used.
 
 
-**Before running this command**, ensure that you have a `package.json` file in the `PLAYWRIGHT_TEST_DIR` folder. 
+**Before running this command**, ensure that you have a `package.json` file in the `PLAYWRIGHT_TEST_DIR` folder.
 
-You will find an example of such a file in the `tests/project_root/tests/Playwright`folder of this repository. 
+You will find an example of such a file in the `tests/project_root/tests/Playwright`folder of this repository.
 
 <details>
 
@@ -210,7 +213,7 @@ You can choose to use `npm` or `yarn` as package manager by using the `--pm` opt
 
 You can run all the playwright command with `ddev playwright [command]`.
 
-- To run playwright's test command: 
+- To run playwright's test command:
 
   ```bash
   ddev playwright test
@@ -244,7 +247,7 @@ When running in UI/headed mode, you can use the provided Kasmvnc service by brow
 
 ![kasmvnc](./docs/kasmvnc.jpg)
 
-It could be also used to generate playwright code by browsing with the following command: 
+It could be also used to generate playwright code by browsing with the following command:
 
 ```bash
 ddev playwright codegen
@@ -254,7 +257,7 @@ ddev playwright codegen
 
 As for any DDEV additional service, you can use the `ddev exec -s playwright [command]` snippet to run a command in the playwright container.
 
-For example: 
+For example:
 
 - `ddev exec -s playwright yarn install --cwd ./var/www/html/yarn --force`
 - `ddev exec -s playwright yarn --cwd /var/www/html/yarn test "__tests__/1-simple-test.js"`
@@ -263,10 +266,10 @@ For example:
 
 ### `.npmrc` file and `.ddev/homeadditions`
 
-If you wish to use a specific `.npmrc` file (for private NPM registries for example), you just need to place the `.npmrc` file in the `.ddev/homeadditions` folder of your project. This way, the `ddev playwright-install` command 
+If you wish to use a specific `.npmrc` file (for private NPM registries for example), you just need to place the `.npmrc` file in the `.ddev/homeadditions` folder of your project. This way, the `ddev playwright-install` command
 will automatically retrieve it.
 
-More generally, all the `.ddev/homeadditions` folder content is copied to `/home/pwuser` folder when the `playwright` 
+More generally, all the `.ddev/homeadditions` folder content is copied to `/home/pwuser` folder when the `playwright`
 container is build.
 
 

--- a/docker-compose.playwright.yaml
+++ b/docker-compose.playwright.yaml
@@ -33,6 +33,4 @@ services:
       - .:/mnt/ddev_config
       - ddev-global-cache:/mnt/ddev-global-cache
       - ../:/var/www/html:rw
-    external_links:
-      - ddev-router:${DDEV_HOSTNAME}
     working_dir: /var/www/html

--- a/install.yaml
+++ b/install.yaml
@@ -10,3 +10,36 @@ project_files:
 - playwright-build/xstartup
 - playwright-build/entrypoint.sh
 - docker-compose.playwright.yaml
+
+post_install_actions:
+  - |
+    #ddev-nodisplay
+    #ddev-description:Checking docker-compose.playwright_extras.yaml for changes
+    if [ -f docker-compose.playwright_extras.yaml ] && ! grep -q '#ddev-generated' docker-compose.playwright_extras.yaml; then
+      echo "Existing docker-compose.playwright_extras.yaml does not have #ddev-generated, so can't be updated"
+      exit 2
+    fi
+  - |
+    #ddev-nodisplay
+    #ddev-description:Adding all hostnames to the playwright container to make them available
+    cat <<-END >docker-compose.playwright_extras.yaml
+    #ddev-generated
+    services:
+      playwright:
+        external_links:
+        {{- $playwright_hostnames := splitList "," (env "DDEV_HOSTNAME") -}}
+        {{- range $i, $n := $playwright_hostnames }}
+          - "ddev-router:{{- replace (env "DDEV_TLD") "\\${DDEV_TLD}" (replace (env "DDEV_PROJECT") "\\${DDEV_PROJECT}" $n) -}}"
+        {{- end }}
+    END
+removal_actions:
+  - |
+    #ddev-nodisplay
+    #ddev-description:Remove docker-compose.playwright_extras.yaml file
+    if [ -f docker-compose.playwright_extras.yaml ]; then
+      if grep -q '#ddev-generated' docker-compose.playwright_extras.yaml; then
+        rm -f docker-compose.playwright_extras.yaml
+      else
+        echo "Unwilling to remove '$DDEV_APPROOT/.ddev/docker-compose.playwright_extras.yaml' because it does not have #ddev-generated in it; you can manually delete it if it is safe to delete."
+      fi
+    fi


### PR DESCRIPTION
## The Issue

From Discord: https://discord.com/channels/664580571770388500/1326111991642718301

`external_links` don't work properly when you have `additional_hostnames` or `additional_fqdns`.

https://github.com/julienloizelet/ddev-playwright/blob/26520ac7a172bd1943f2c2c079364a25512ca291/docker-compose.playwright.yaml#L36-L37

```yaml
 external_links: 
   - "ddev-router:${DDEV_HOSTNAME}"
```

It is expanded with an invalid syntax:

```yaml
 external_links: 
   - "ddev-router:primary.ddev.site,secondary.ddev.site"
```

It should look like this:

```yaml
 external_links: 
   - "ddev-router:primary.ddev.site"
   - "ddev-router:secondary.ddev.site"
```

## How This PR Solves The Issue

Uses go templates to create the correct `external_links` in `.ddev/docker-compose.playwright_extras.yaml`

## Manual Testing Instructions

This allows for example to have Mailpit to work automatically without any port change.

```
mkdir playwright-test && cd playwright-test
ddev config --additional-fqdns="hello.test" --additional-hostnames "extra1,extra2,more.extra"
echo '<?php echo "Hello World;"; ?>' > index.php
ddev add-on get https://github.com/stasadev/ddev-playwright/tarball/20250107_stasadev_external_links

cat .ddev/docker-compose.playwright_extras.yaml
#ddev-generated
services:
  playwright:
    external_links:
      - "ddev-router:${DDEV_PROJECT}.${DDEV_TLD}"
      - "ddev-router:extra1.${DDEV_TLD}"
      - "ddev-router:extra2.${DDEV_TLD}"
      - "ddev-router:hello.test"
      - "ddev-router:more.extra.${DDEV_TLD}"

ddev start

cat .ddev/.ddev-docker-compose-full.yaml
        external_links:
            - ddev-router:playwright-test.ddev.site
            - ddev-router:extra1.ddev.site
            - ddev-router:extra2.ddev.site
            - ddev-router:hello.test
            - ddev-router:more.extra.ddev.site
```

## Related Issue Link(s)

- https://github.com/tyler36/ddev-cypress/pull/54
