### PR TITLE
feat(*): Do not create docker-compose.playwright_extras.yaml file

### DIFF
--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: extension
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           echo "VERSION_NUMBER=$(echo ${{ github.event.inputs.tag_name }} | sed 's/v//g' )" >> $GITHUB_ENV
 
       - name: Clone sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check version ${{ env.VERSION_NUMBER }} consistency in files
         # Check CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,25 @@ The public API for this project is defined by the files `docker-compose.playwrig
 
 ---
 
+## [2.4.0](https://github.com/julienloizelet/ddev-playwright/releases/tag/v2.4.0) - 2025-??-??
+
+[_Compare with previous release_](https://github.com/julienloizelet/ddev-playwright/compare/v2.3.0...v2.4.0)
+
+### Changed
+
+- Set `1.24.9` as the minimum required DDEV version
+- Do not create `docker-compose.playwright_extras.yaml` file anymore as [DDEV 1.24.9+ handles network aliases 
+  automatically](https://github.com/ddev/ddev/pull/7642)
+
+---
+
 ## [2.3.0](https://github.com/julienloizelet/ddev-playwright/releases/tag/v2.3.0) - 2025-05-12
 
 [_Compare with previous release_](https://github.com/julienloizelet/ddev-playwright/compare/v2.2.1...v2.3.0)
 
 ### Added
 
-- - Add `PLAYWRIGHT_DOCKER_IMAGE` variable to customize the Docker image
+- Add `PLAYWRIGHT_DOCKER_IMAGE` variable to customize the Docker image
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,6 @@ Then restart your project
 ddev restart
 ```
 
-> [!NOTE]
-> If you change `additional_hostnames` or `additional_fqdns`, you have to re-run `ddev add-on get julienloizelet/ddev-playwright`.
-
 ## Basic usage
 
 ### Quick start

--- a/install.yaml
+++ b/install.yaml
@@ -11,35 +11,21 @@ project_files:
 - playwright-build/entrypoint.sh
 - docker-compose.playwright.yaml
 
-post_install_actions:
+ddev_version_constraint: '>= v1.24.9'
+
+pre_install_actions:
   - |
     #ddev-nodisplay
-    #ddev-description:Checking docker-compose.playwright_extras.yaml for changes
-    if [ -f docker-compose.playwright_extras.yaml ] && ! grep -q '#ddev-generated' docker-compose.playwright_extras.yaml; then
-      echo "Existing docker-compose.playwright_extras.yaml does not have #ddev-generated, so can't be updated"
-      exit 2
-    fi
-  - |
-    #ddev-nodisplay
-    #ddev-description:Adding all hostnames to the playwright container to make them available
-    cat <<-END >docker-compose.playwright_extras.yaml
-    #ddev-generated
-    services:
-      playwright:
-        external_links:
-        {{- $playwright_hostnames := splitList "," (env "DDEV_HOSTNAME") -}}
-        {{- range $i, $n := $playwright_hostnames }}
-          - "ddev-router:{{- replace (env "DDEV_TLD") "\\${DDEV_TLD}" (replace (env "DDEV_PROJECT") "\\${DDEV_PROJECT}" $n) -}}"
-        {{- end }}
-    END
-removal_actions:
-  - |
-    #ddev-nodisplay
-    #ddev-description:Remove docker-compose.playwright_extras.yaml file
+    #ddev-description:Removing old docker-compose.playwright_extras.yaml file (created by old versions of this add-on)
+    has_old_file=false
     if [ -f docker-compose.playwright_extras.yaml ]; then
       if grep -q '#ddev-generated' docker-compose.playwright_extras.yaml; then
         rm -f docker-compose.playwright_extras.yaml
       else
-        echo "Unwilling to remove '$DDEV_APPROOT/.ddev/docker-compose.playwright_extras.yaml' because it does not have #ddev-generated in it; you can manually delete it if it is safe to delete."
+        echo "'$DDEV_APPROOT/.ddev/docker-compose.playwright_extras.yaml' needs to be removed but has been modified by the user. Please check it and remove it"
+        has_old_file=true
       fi
+    fi
+    if [ "${has_old_file}" = true ]; then
+      exit 2
     fi


### PR DESCRIPTION

Network aliases are automatically managed by DDEV 1.24.9+

## The Issue

- #29

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
